### PR TITLE
add check-sidecar-ready helper

### DIFF
--- a/helper-check-service-ready
+++ b/helper-check-service-ready
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# HELPER PURPOSE
+#
+# Checks availability of service containers
+
+# Set error handling
+set -eu -o pipefail
+
+DOCKERIZE_VERSION=v0.3.0
+wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+for var in "$@"
+do
+    case $var in
+    redis)
+      dockerize -wait tcp://localhost:6379 -timeout 1m
+      ;;
+    neo4j)
+      dockerize -wait tcp://localhost:7687 -timeout 1m
+      ;;
+    esac
+done

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -6,6 +6,7 @@ module.exports = {
 			'helper-npm-install-peer-deps',
 			'helper-npm-store-auth-token',
 			'helper-npm-update',
+			'helper-check-service-ready',
 			'helper-npm-version-and-publish-public',
 			'helper-setup-heroku-cli',
 			'helper-setup-s3-upload',


### PR DESCRIPTION
# add check-sidecar-ready helper 

## What
- installs dockerise
- takes arguments of things to check (at the mo only supports neo4j and redis)

## Checks
- 🐿 v2.10.0