### PR TITLE
Fix helper-npm-install-peer-deps

### DIFF
--- a/helper-npm-install-peer-deps
+++ b/helper-npm-install-peer-deps
@@ -22,7 +22,11 @@
 #
 
 # Set error handling
-set -eu -o pipefail
+#
+# Do *not* set `-o pipefail` as `npm ls --production --parseable`
+# will have an exit code of 1 when there are missing peer
+# dependencies, but that's what we're expecting to happen
+set -eu
 
 # HELPER COMMANDS
 


### PR DESCRIPTION
Because we had `set -o pipefail` at the top of the script, whenever `npm ls --production --parseable` raised an error for a missing peer dependency it would have a failure return code, which then in turn caused the pipeline of commands to produce a failure return code. Because we also had `set -e`, any failing command causes the script to exit with an exit code of 1.

This change allows for `npm ls --production --parseable` to have a failure return code, as that's what we're expecting to happen when there's a missing peer dependency, which we will then install.

Lol computers.

 🐿 v2.10.2