### PR TITLE
Removes sudo commands

### DIFF
--- a/helper-check-service-ready
+++ b/helper-check-service-ready
@@ -16,7 +16,7 @@ else
 	echo 'wget or curl are required to run helper-check-service-ready'
 	exit 1
 fi	
-sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 for var in "$@"


### PR DESCRIPTION
Sudo is not available in the docker image for lambda. I don't think any should need to run this as sudo