### PR TITLE
Update helper-npm-update

### DIFF
--- a/helper-npm-update
+++ b/helper-npm-update
@@ -17,10 +17,14 @@
 #   package-lock.json, we use the checksum of package.json
 #   for some CI tasks e.g. naming node_module caches
 #
+# --depth - 
+#   Ensure all subdependencies are updated too
+#   https://trello.com/c/xVnHAakZ/447-use-the-old-npm-update-behaviour-in-our-cirleci-shared-helpers
+#
 
 # Set error handling
 set -eu -o pipefail
 
 # HELPER COMMANDS
 
-npm update --dev --no-package-lock --no-save
+npm update --dev --no-package-lock --no-save --depth 9999


### PR DESCRIPTION
caveat: there is a small risk, like the recent problem we found with x-dash and jest's vs eslint's use of acorn and peer dependencies, that this might cause an app to break. There is the risk that an app might break just with top-level too, the more that gets updated the more risk there is.