### PR TITLE
Add heroku-repo plugin

### DIFF
--- a/helper-setup-heroku-cli
+++ b/helper-setup-heroku-cli
@@ -22,7 +22,7 @@ sudo ln -s /usr/local/lib/heroku/bin/heroku /usr/local/bin/heroku
 # build log what version is being used
 heroku --version
 
-# Heroku Repo plugin allows us to clear the git repo, so we can force deploys on circel Rebuild
+# Heroku Repo plugin allows us to clear the git repo, so we can force deploys on circle rebuild
 heroku plugins:install heroku-repo
 
 # Heroku CLI Authentication - Netrc file format

--- a/helper-setup-heroku-cli
+++ b/helper-setup-heroku-cli
@@ -22,6 +22,9 @@ sudo ln -s /usr/local/lib/heroku/bin/heroku /usr/local/bin/heroku
 # build log what version is being used
 heroku --version
 
+# Heroku Repo plugin allows us to clear the git repo, so we can force deploys on circel Rebuild
+heroku plugins:install heroku-repo
+
 # Heroku CLI Authentication - Netrc file format
 # https://devcenter.heroku.com/articles/authentication#netrc-file-format
 


### PR DESCRIPTION
This is used as part of our new heroku deploy process, to enable rebuilds of `master` to always deploy despite there being no code changes.


https://github.com/Financial-Times/next/issues/232