### PR TITLE
feat: install jq

### DIFF
--- a/helper-install-puppeteer-deps
+++ b/helper-install-puppeteer-deps
@@ -10,7 +10,8 @@ set -eu -o pipefail
 
 # HELPER COMMANDS
 
-sudo apt-get update && \
+sudo apt-get update
+
 sudo apt-get install -yq \
     gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 \
     libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 \
@@ -19,3 +20,6 @@ sudo apt-get install -yq \
     libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 \
     libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
     fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+
+# This is used in the request to the Change API made after deployments
+sudo apt-get install -yq jq


### PR DESCRIPTION
This is used by the Change API request.

It looks like the package is already installed on the CircleCI images, but this is to ensure it's availabe if they change their default installed packages.