### PR TITLE
add an install-awscli helper 🐿 v2.12.5

### DIFF
--- a/helper-configure-awscli
+++ b/helper-configure-awscli
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# HELPER PURPOSE
+#
+# Configures the awscli tool with aws authentication keys
+#
+
+# Set error handling
+set -eu -o pipefail
+
+# HELPER COMMANDS
+
+# provide keys as arguments when invoking the helper
+access_key_id="$1"
+secret_access_key="$2"
+
+# write the auth keys to .aws/credentials
+aws configure set aws_access_key_id "$access_key_id"
+aws configure set aws_secret_access_key "$secret_access_key"
+

--- a/helper-install-awscli
+++ b/helper-install-awscli
@@ -2,7 +2,7 @@
 #
 # HELPER PURPOSE
 #
-# Installs the awscli tool and sets the aws authentication keys
+# Installs the awscli tool
 #
 
 # Set error handling
@@ -12,7 +12,3 @@ set -eu -o pipefail
 
 # install the awscli
 sudo pip install awscli
-
-# write the auth keys to .aws/credentials
-aws configure set aws_access_key_id $aws_access_hashed_assets
-aws configure set aws_secret_access_key $aws_secret_hashed_assets

--- a/helper-install-awscli
+++ b/helper-install-awscli
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# HELPER PURPOSE
+#
+# Installs the awscli tool and sets the aws authentication keys
+#
+
+# Set error handling
+set -eu -o pipefail
+
+# HELPER COMMANDS
+
+# install the awscli
+sudo pip install awscli
+
+# write the auth keys to .aws/credentials
+aws configure set aws_access_key_id $aws_access_hashed_assets
+aws configure set aws_secret_access_key $aws_secret_hashed_assets

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -2,6 +2,7 @@ module.exports = {
 	files: {
 		allow: [
 			'helper-generate-build-state-artifacts',
+			'helper-configure-awscli',
 			'helper-install-awscli',
 			'helper-install-puppeteer-deps',
 			'helper-npm-install-peer-deps',

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -2,6 +2,7 @@ module.exports = {
 	files: {
 		allow: [
 			'helper-generate-build-state-artifacts',
+			'helper-install-awscli',
 			'helper-install-puppeteer-deps',
 			'helper-npm-install-peer-deps',
 			'helper-npm-store-auth-token',


### PR DESCRIPTION
Adds a helper to install the `awscli` tool and configure its required environment variables. It will be used by [the upload assets helper](https://github.com/Financial-Times/next-ci-shared-helpers/pull/23) to deploy assets to S3

This is required along with https://github.com/Financial-Times/next-ci-shared-helpers/pull/22 to remove the dependency on n-heroku-tools when deploying assets for Page Kit apps. 

Related n-gage changes: https://github.com/Financial-Times/n-gage/pull/213

Related issue on Page Kit: https://github.com/Financial-Times/next-ci-shared-helpers/issues/21