### PR TITLE
Only install unique peer deps

### DIFF
--- a/helper-npm-install-peer-deps
+++ b/helper-npm-install-peer-deps
@@ -33,7 +33,7 @@ set -eu
 if [ -e package.json ]; then
 
     npm ls --production --parseable 2>&1 >/dev/null | \
-      sed -n -e 's/^npm ERR! peer dep missing: \(.*\),.*/\1/p' | \
+      sed -n -e 's/^npm ERR! peer dep missing: \(.*\),.*/\1/p' | uniq | \
         xargs -I{} npm install --no-package-lock --no-save "{}"
 
 fi


### PR DESCRIPTION
Currently, the same peer dependency may be installed multiple times. This PR ensures each unique peer dependency is only installed a single time.