### PR TITLE
CPP-344 Migrated x-dash's script to deploy to Github Pages to this repo

### DIFF
--- a/helper-publish-gh-pages
+++ b/helper-publish-gh-pages
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# HELPER PURPOSE
+#
+# Deploy to Github Pages
+
+
+TARGET_DIR=web/public/*
+TARGET_BRANCH=gh-pages
+TEMP_DIR=tmp
+
+# Set error handling
+set -eu -o pipefail
+
+# Set GitHub user information (the email must match the SSH key provided to Circle)
+git config --global user.email $GITHUB_EMAIL
+git config --global user.name $GITHUB_NAME
+
+# HACK: Add GitHub to known hosts to avoid an interactive prompt when cloning over SSH
+mkdir -p ~/.ssh
+ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+
+# Clone only the branch we need so we don't download all of the project history
+git clone $CIRCLE_REPOSITORY_URL $TEMP_DIR --single-branch --branch $TARGET_BRANCH
+
+# Remove all of the files, -q prevents logging every filename
+cd $TEMP_DIR
+git rm -rf .
+cd ..
+
+# Copy contents of target directory to the deployment directory
+cp -R -L $TARGET_DIR $TEMP_DIR
+
+# Copy CI config (which should instruct Circle to ignore this branch)
+cp -r .circleci $TEMP_DIR
+
+cd $TEMP_DIR
+
+# Stage and commit all of the files
+git add -A &> /dev/null
+git commit -m "Automated deployment to GitHub Pages: ${CIRCLE_SHA1}" --allow-empty
+
+# Push to the target branch, staying quiet unless something goes wrong
+git push -q origin $TARGET_BRANCH

--- a/helper-publish-github-pages
+++ b/helper-publish-github-pages
@@ -6,7 +6,7 @@
 
 
 TARGET_DIR=web/public/*
-TARGET_BRANCH=gh-pages
+TARGET_BRANCH=github-pages
 TEMP_DIR=tmp
 
 # Set error handling

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -10,7 +10,7 @@ module.exports = {
 			'helper-npm-update',
 			'helper-check-service-ready',
 			'helper-npm-version-and-publish-public',
-			'helper-publish-gh-pages',
+			'helper-publish-github-pages',
 			'helper-setup-heroku-cli',
 			'helper-setup-s3-upload',
 			'helper-upload-assets-to-s3',

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -10,6 +10,7 @@ module.exports = {
 			'helper-npm-update',
 			'helper-check-service-ready',
 			'helper-npm-version-and-publish-public',
+			'helper-publish-gh-pages',
 			'helper-setup-heroku-cli',
 			'helper-setup-s3-upload',
 			'helper-upload-assets-to-s3',


### PR DESCRIPTION
 Ticket [CPP-344 Publish a script to allow any component to publish a Storybook](https://financialtimes.atlassian.net/browse/CPP-344)
 
 As part of the work for creating a single storybook composed of X-dash's, PageKit's, and other storybooks ([CPP-345](https://financialtimes.atlassian.net/browse/CPP-345)) the tooling is being abstracted from single Storybook repos, so that it can be reused.

This script will be used in the following way during the deploy task:
```
- run:
     name: shared-helper / publish-gh-pages
     command: .circleci/shared-helpers/helper-publish-gh-pages
```