### PR TITLE
CPP-344 - Change helper-publish-github-pages target branch name back to gh-pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ _The convention across all FT repos is to name the step as follows: `shared-help
 - Include links to any relevant documentation in your comments
 - Try and avoid noisy output - it's hard to debug CI builds or understand what has happened if there are lots of unnecessary messages in the shell output
 - Echo out useful messages about progress and actions taken by the script - the flip side of avoiding noisy output: humans want to know what's happening/happened with their build
+- Remember to make your script executable by running the command `chmod +x ./<NAME_OF_SCRIPT>`
 
 ### Naming guidelines
 

--- a/helper-publish-github-pages
+++ b/helper-publish-github-pages
@@ -6,7 +6,7 @@
 
 
 TARGET_DIR=web/public/*
-TARGET_BRANCH=github-pages
+TARGET_BRANCH=gh-pages
 TEMP_DIR=tmp
 
 # Set error handling


### PR DESCRIPTION
I had changed the script's target branch from `gh-pages` to `github-pages` but I just realized that `gh-pages` is the conventional name for that branch based on the [Github Pages Docs](https://docs.github.com/en/free-pro-team@latest/github/working-with-github-pages/creating-a-github-pages-site#next-steps)

In this PR I also added a reminder to the README under `General guidelines for helper scripts` to remember to make them executable