### PR TITLE
helper-publish-github-pages - remove TARGET_DIR

### DIFF
--- a/helper-publish-github-pages
+++ b/helper-publish-github-pages
@@ -3,9 +3,8 @@
 # HELPER PURPOSE
 #
 # Deploy to Github Pages
+# Your project should set the GITHUB_EMAIL, GITHUB_NAME and TARGET_DIR variables in Vault
 
-
-TARGET_DIR=web/public/*
 TARGET_BRANCH=gh-pages
 TEMP_DIR=tmp
 


### PR DESCRIPTION
Removed setting TARGET_DIR and added a comment of what variables should be set in Vault, so that the TARGET_DIR can be dynamic depending on each project