### PR TITLE
Update comments to reflect package-lock.json policy

### DIFF
--- a/helper-npm-install-peer-deps
+++ b/helper-npm-install-peer-deps
@@ -13,14 +13,12 @@
 #
 # --no-package-lock - While we now use package-lock.json 
 #   in our repos, skip package-lock.json in this instance 
-#   as we're bypassing the normal npm install process     
-#   and don't want to accidentally modify the file in CI.
-#   Normal dependencies are still installed via `make install` 
-#   which does use the package-lock.
+#   as we don't want to accidentally modify the file 
+#   for subsequent steps in the workflow, e.g cache keys 
+#   and artefact generation.
 #
-# --no-save - Don't update package.json - as we don't use
-#   package-lock.json, we use the checksum of package.json
-#   for some CI tasks e.g. naming node_module caches
+# --no-save - We don't want to modify package.json as we
+#   use its checksum for some CI tasks e.g. naming node_module caches
 #
 
 # Set error handling

--- a/helper-npm-install-peer-deps
+++ b/helper-npm-install-peer-deps
@@ -11,10 +11,12 @@
 #
 # Why we pass the flags we do to `npm install`:
 #
-# --no-package-lock - Don't write a package-lock.json as
-#   we don't use it and it can cause issues with `npm ls`,
-#   which is run by subsequent tasks in CI:
-#   https://github.com/npm/npm/issues/19393
+# --no-package-lock - While we now use package-lock.json 
+#   in our repos, skip package-lock.json in this instance 
+#   as we're bypassing the normal npm install process     
+#   and don't want to accidentally modify the file in CI.
+#   Normal dependencies are still installed via `make install` 
+#   which does use the package-lock.
 #
 # --no-save - Don't update package.json - as we don't use
 #   package-lock.json, we use the checksum of package.json

--- a/helper-npm-update
+++ b/helper-npm-update
@@ -8,10 +8,12 @@
 #
 # --dev - Also update devDependencies
 #
-# --no-package-lock - Don't write a package-lock.json as
-#   we don't use it and it can cause issues with `npm ls`,
-#   which is run by subsequent tasks in CI:
-#   https://github.com/npm/npm/issues/19393
+# --no-package-lock - While we now use package-lock.json 
+#   in our repos, skip package-lock.json in this instance 
+#   as we're bypassing the normal npm install process     
+#   and don't want to accidentally modify the file in CI.
+#   Normal dependencies are still installed via `make install` 
+#   which does use the package-lock.
 #
 # --no-save - Don't update package.json - as we don't use
 #   package-lock.json, we use the checksum of package.json

--- a/helper-npm-update
+++ b/helper-npm-update
@@ -10,14 +10,12 @@
 #
 # --no-package-lock - While we now use package-lock.json 
 #   in our repos, skip package-lock.json in this instance 
-#   as we're bypassing the normal npm install process     
-#   and don't want to accidentally modify the file in CI.
-#   Normal dependencies are still installed via `make install` 
-#   which does use the package-lock.
+#   as we don't want to accidentally modify the file 
+#   for subsequent steps in the workflow, e.g cache keys 
+#   and artefact generation.
 #
-# --no-save - Don't update package.json - as we don't use
-#   package-lock.json, we use the checksum of package.json
-#   for some CI tasks e.g. naming node_module caches
+# --no-save - We don't want to modify package.json as we
+#   use its checksum for some CI tasks e.g. naming node_module caches
 #
 
 # Set error handling


### PR DESCRIPTION
As per [CPP-411](https://financialtimes.atlassian.net/browse/CPP-411)

Update comments in helper-npm-install-peer-deps and helper-npm-update to reflect the fact that we now use package-lock.json, but should still use the --no-package-lock flag in this instance.

I _think_ I have understood correctly, but apologies if not! 😄 