### PR TITLE
Install all the peer-dependencies with a single `npm install`

### DIFF
--- a/helper-npm-install-peer-deps
+++ b/helper-npm-install-peer-deps
@@ -34,6 +34,7 @@ if [ -e package.json ]; then
 
     npm ls --production --parseable 2>&1 >/dev/null | \
       sed -n -e 's/^npm ERR! peer dep missing: \(.*\),.*/\1/p' | \
-        xargs -I{} npm install --no-package-lock --no-save "{}"
+        xargs -I{} echo -n '"{}" ' | \
+          xargs -I{} npm install --no-package-lock --no-save "{}"
 
 fi


### PR DESCRIPTION
Previously the helper would install the peer-dependencies one at a time which can lead to a slower install times compared to installing all the peer-dependencies in a single `npm install`.

I came across this because the project I was working on had a `postinstall` npm run-script which was slow and it was being run after each individual peer-dependency was installed. Switching to install all the peer-dependencies in one go meant that the slow `postinstall` script was only run once.